### PR TITLE
Implement getOriginIPFromXForwarded header

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/env/GetOriginIPFromXForwardedFunction.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/env/GetOriginIPFromXForwardedFunction.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.execution.env;
+
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.ReturnAttribute;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.executor.function.FunctionExecutor;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class provides a function to get immediate public IP of the origin from X-Forwarded-For header.
+ */
+@Extension(
+        name = "getOriginIPFromXForwarded",
+        namespace = "env",
+        description = "This function returns the public origin IP from the given X-Forwarded header",
+        returnAttributes = @ReturnAttribute(
+                description = "public IP related to the origin which is retrieved using the given X-Forwarded header",
+                type = {DataType.STRING}),
+        parameters = {
+                @Parameter(name = "xforwardedheader",
+                        description = "X-Forwarded-For header of the request",
+                        type = {DataType.STRING}
+                )
+        },
+        examples = {
+                @Example(
+                        syntax = "define stream InputStream (xForwardedHeader string);\n" +
+                                "from InputStream " +
+                                "select env:getOriginIPFromXForwarded(xForwardedHeader) as originIP \n" +
+                                "insert into OutputStream;",
+                        description = "This query returns the public origin IP from the given X-Forwarded header"
+                )
+        }
+)
+public class GetOriginIPFromXForwardedFunction extends FunctionExecutor {
+
+    private static final String IP_ADDRESS_PATTERN = "^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." +
+            "([01]?\\d\\d?|2[0-4]\\d|25[0-5])$";
+    private static final String PRIVATE_IP_ADDRESS_PATTERN = "(^127\\..*)|(^10\\..*)|(^172\\.1[6-9]\\..*)|" +
+            "(^172\\.2[0-9]\\..*)|(^172\\.3[0-1]\\..*)|(^192\\.168\\..*)";
+    private static Pattern ipPAddressPattern = Pattern.compile(IP_ADDRESS_PATTERN);
+    private static Pattern privateIPPAddressPattern = Pattern.compile(PRIVATE_IP_ADDRESS_PATTERN);
+
+    /**
+     * The initialization method for GetOriginIPFromXForwardedFunction,
+     * this method will be called before the other methods.
+     *
+     * @param attributeExpressionExecutors the executors of each function parameter.
+     * @param siddhiAppContext             the context of the execution plan.
+     */
+    protected void init(ExpressionExecutor[] attributeExpressionExecutors, ConfigReader reader,
+                        SiddhiAppContext siddhiAppContext) {
+        if (attributeExpressionExecutors.length != 1) {
+            throw new SiddhiAppValidationException("Invalid no of arguments passed to env:getOriginIPFromXForwarded" +
+                    "() function, required 1, but found " + attributeExpressionExecutors.length);
+        }
+
+        Attribute.Type attributeType = attributeExpressionExecutors[0].getReturnType();
+        if (attributeType != Attribute.Type.STRING) {
+            throw new SiddhiAppValidationException("Invalid parameter type found for first argument " +
+                    "'xForwardedHeader' of env:getOriginIPFromXForwarded() function, required " + Attribute.Type
+                    .STRING + ", but found " + attributeType.toString());
+        }
+
+    }
+
+    /**
+     * The main execution method which will be called upon event arrival
+     * when there are more than one function parameter.
+     *
+     * @param data the runtime values of function parameters.
+     * @return the function result.
+     */
+    @Override
+    protected Object execute(Object[] data) {
+        //we only allow single parameter for this function
+        return null;
+    }
+
+    /**
+     * The main execution method which will be called upon event arrival
+     * when there are zero or one function parameter.
+     *
+     * @param data null if the function parameter count is zero or
+     *             runtime data value of the function parameter.
+     * @return the function result.
+     */
+    @Override
+    protected Object execute(Object data) {
+        String xForwardedFor = data.toString();
+        if (xForwardedFor.isEmpty()) {
+            return null;
+        }
+        String extractedIPs[] = xForwardedFor.split(",", -1);
+        Matcher privateIPAddressMatcher;
+        Matcher ipAddressMatcher;
+        String filteredPublicIp = null;
+        String extractedIP;
+        for (int i = 0, extractedIPsLength = extractedIPs.length; i < extractedIPsLength; i++) {
+            extractedIP = extractedIPs[i].trim();
+            privateIPAddressMatcher = privateIPPAddressPattern.matcher(extractedIP);
+            if (!privateIPAddressMatcher.matches()) {
+                ipAddressMatcher = ipPAddressPattern.matcher(extractedIP);
+                if (ipAddressMatcher.matches()) {
+                    filteredPublicIp = extractedIP;
+                    break;
+                }
+
+            }
+        }
+        return filteredPublicIp;
+    }
+
+    /**
+     * This will be called only once and this can be used to acquire
+     * required resources for the processing element.
+     * This will be called after initializing the system and before
+     * starting to process the events.
+     */
+
+    @Override
+    public Attribute.Type getReturnType() {
+        return Attribute.Type.STRING;
+    }
+
+    /**
+     * Used to collect the serializable state of the processing element, that need to be
+     * persisted for the reconstructing the element to the same state on a different point of time.
+     *
+     * @return stateful objects of the processing element as an array.
+     */
+    @Override
+    public Map<String, Object> currentState() {
+        return null;
+    }
+
+    /**
+     * Used to restore serialized state of the processing element, for reconstructing
+     * the element to the same state as if was on a previous point of time.
+     *
+     * @param state the stateful objects of the element as an array on
+     *              the same order provided by currentState().
+     */
+    @Override
+    public void restoreState(Map<String, Object> state) {
+
+    }
+}

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/env/GetOriginIPFromXForwardedFunctionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/env/GetOriginIPFromXForwardedFunctionTestCase.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.execution.env;
+
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.stream.input.InputHandler;
+import org.wso2.siddhi.core.util.EventPrinter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GetOriginIPFromXForwardedFunctionTestCase {
+    private static Logger logger = Logger.getLogger(GetOriginIPFromXForwardedFunctionTestCase.class);
+    private AtomicInteger count = new AtomicInteger(0);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        count.set(0);
+        eventArrived = false;
+    }
+
+    @Test
+    public void testDefaultBehaviour1() throws Exception {
+        logger.info("GetOriginIPFromXForwardedFunction default behaviour testCase");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String stream = "define stream inputStream (xForwardedHeader string);\n";
+        String query = ("@info(name = 'query1') from inputStream \n"
+                + "select env:getOriginIPFromXForwarded(xForwardedHeader) as originIP \n" +
+                "insert into outputStream;");
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stream + query);
+        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents,
+                                Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    count.incrementAndGet();
+                    switch (count.get()) {
+                        case 1:
+                            AssertJUnit.assertEquals(null, event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 2:
+                            AssertJUnit.assertEquals("203.160.190.196", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 3:
+                            AssertJUnit.assertEquals(null, event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 4:
+                            AssertJUnit.assertEquals("203.160.190.198", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 5:
+                            AssertJUnit.assertEquals("199.207.253.101", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 6:
+                            AssertJUnit.assertEquals("208.160.190.198", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 7:
+                            AssertJUnit.assertEquals("210.160.190.198", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 8:
+                            AssertJUnit.assertEquals("70.41.3.18", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 9:
+                            AssertJUnit.assertEquals("70.41.3.18", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 10:
+                            AssertJUnit.assertEquals("70.41.3.18", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 11:
+                            AssertJUnit.assertEquals("14.3.49.206", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 12:
+                            AssertJUnit.assertEquals("210.160.190.217", event.getData(0));
+                            eventArrived = true;
+                            break;
+                        case 13:
+                            AssertJUnit.assertEquals("210.160.180.117", event.getData(0));
+                            eventArrived = true;
+                            break;
+                    }
+                }
+            }
+        });
+        InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+        siddhiAppRuntime.start();
+        inputHandler.send(new Object[]{" "});
+        inputHandler.send(new Object[]{"203.160.190.196,10.1.1.1"});
+        inputHandler.send(new String[]{"192.168.1.103"});
+        inputHandler.send(new String[]{"192.168.1.103, 203.160.190.198"});
+        inputHandler.send(new String[]{"10.3.49.206,            199.207.253.101"});
+        inputHandler.send(new String[]{"10.3.49.206, 192.168.1.103, 208.160.190.198"});
+        inputHandler.send(new String[]{"10.3.50.233, 192.168.1.103,           210.160.190.198"});
+        inputHandler.send(new String[]{"10.4.49.234,             70.41.3.18    , 210.160.190.200"});
+        inputHandler.send(new String[]{"10.5.49.216, 70.41.3.18, 192.168.1.103,           210.160.190.208"});
+        inputHandler.send(new String[]{"10.3.39.226, 70.41.3.18, 192.168.1.103, a.a.a.a"});
+        inputHandler.send(new String[]{"14.3.49.206, , 192.168.1.103, 210.160.190.208"});
+        inputHandler.send(new String[]{", a.a.a.a, 192.168.1.103, 210.160.190.217"});
+        inputHandler.send(new String[]{",, 192.168.1.103, 210.160.180.117"});
+        AssertJUnit.assertEquals(13, count.get());
+        AssertJUnit.assertTrue(eventArrived);
+        siddhiAppRuntime.shutdown();
+    }
+}

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.extension.siddhi.execution.env.GetEnvironmentPropertyFunctionExtensionTestCase" />
             <class name="org.wso2.extension.siddhi.execution.env.GetYAMLPropertyFunctionExtensionTestCase" />
             <class name="org.wso2.extension.siddhi.execution.env.GetUserAgentPropertyFunctionExtensionTestCase"/>
+            <class name="org.wso2.extension.siddhi.execution.env.GetOriginIPFromXForwardedFunctionTestCase"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Implement getOriginIPFromXForwarded header

## Goals
Implement getOriginIPFromXForwarded header
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
```
define stream inputStream (xForwardedHeader string);
@info(name = 'query1') from inputStream
select env:getOriginIPFromXForwarded(xForwardedHeader) as originIP 
insert into outputStream;
```
