### PR TITLE
Fix high CPU usage issue while parsing the user agent text

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/env/GetUserAgentPropertyFunction.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/env/GetUserAgentPropertyFunction.java
@@ -33,7 +33,9 @@ import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 import ua_parser.Client;
+import ua_parser.OS;
 import ua_parser.Parser;
+import ua_parser.UserAgent;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -147,16 +149,17 @@ public class GetUserAgentPropertyFunction extends FunctionExecutor {
 
     }
 
-    @Override
     protected Object execute(Object[] data) {
         String userAgent = (String) data[0];
-        Client clientParser = uaParser.parse(userAgent);
         switch (propertyName.toLowerCase(Locale.ENGLISH)) {
             case BROWSER:
-                return clientParser.userAgent.family;
+                UserAgent agent = uaParser.parseUserAgent(userAgent);
+                return agent.family;
             case OPERATING_SYSTEM:
-                return clientParser.os.family;
+                OS operatingSystem = uaParser.parseOS(userAgent);
+                return operatingSystem.family;
             case DEVICE:
+                Client clientParser = uaParser.parse(userAgent);
                 return clientParser.device.family;
             // Default condition will never occur.
             default:


### PR DESCRIPTION
## Purpose
Fix high CPU usage issue while parsing the user agent text

## Goals
Fix high CPU usage issue while parsing the user agent text

## Approach
Use existing parseOS and parseUserAgent methods 

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_191"
Java(TM) SE Runtime Environment (build 1.8.0_191-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.191-b12, mixed mode)
 
## Learning
NA